### PR TITLE
chore: ignore lock files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
+# We don't want lockfiles in stacks, as people could use a different package manager
+# This part will be removed by `remix.init`
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+pnpm-lock.yml
+
 node_modules
 
 /.cache
 /build
 /public/build
+/server/index.js
 .env

--- a/remix.init/gitignore
+++ b/remix.init/gitignore
@@ -1,4 +1,6 @@
 node_modules
 
-/server/index.js
+/.cache
+/build
 /public/build
+.env


### PR DESCRIPTION
## Changelog

This PR prevents what happened with fcb05928cc6eaae9f0ee1bb5f603b288a456af6d explicitly saying to git to not tracks lockfiles.

The `.gitignore` file is then overriden by the `remix.init/index.js` script.