### PR TITLE
Add getMatadorVersion function to retrieve the current Matador version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-
 REDIS_URL=""
+MATADOR_VERSION="1.0.1-pre"

--- a/app/lib/matador/index.server.ts
+++ b/app/lib/matador/index.server.ts
@@ -161,3 +161,7 @@ const getRedisKeys = async (redis: Redis, pattern: string) => {
   }
   return keys;
 };
+
+export const getMatadorVersion = () => {
+  return process.env.MATADOR_VERSION;
+};


### PR DESCRIPTION
Close #10

## Changelog

This PR adds a simple function that retrieve the current Matador version, defined in an env variable.