### PR TITLE
refactor(installation script): add check for env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 REDIS_URL=""
-MATADOR_VERSION="1.0.1-pre"

--- a/app/lib/matador/index.server.ts
+++ b/app/lib/matador/index.server.ts
@@ -104,7 +104,3 @@ export const getQueueJob = async (
   const queue = new Queue(queueName, { connection: redis });
   return queue.getJob(jobId);
 };
-
-export const getMatadorVersion = () => {
-  return process.env.MATADOR_VERSION ?? "Not provided";
-};

--- a/app/routes/matador.tsx
+++ b/app/routes/matador.tsx
@@ -2,15 +2,13 @@ import type { ColorScheme } from "@mantine/core";
 import { ColorSchemeProvider, MantineProvider } from "@mantine/core";
 import type {
   LinksFunction,
-  LoaderFunction,
   MetaFunction,
 } from "@remix-run/node";
-import { Outlet, useCatch, useLoaderData } from "@remix-run/react";
+import { Outlet, useCatch } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { ErrorFallback, NavBar } from "~/lib/matador/components";
 import { themeKeyLocalStorage } from "~/lib/matador/helpers/application-helpers.server";
 import { Navigations } from "~/lib/matador/helpers/ui-helpers";
-import { getMatadorVersion } from "~/lib/matador/index.server";
 
 export const links: LinksFunction = () => {
   return [
@@ -26,18 +24,12 @@ export const meta: MetaFunction = () => ({
   title: "Matador",
 });
 
-export type LoaderData = string | undefined;
-
 export interface ErrorBoundaryProps {
   error: Error;
 }
 
-export const loader: LoaderFunction = (): LoaderData => {
-  return getMatadorVersion();
-};
 
 export default function MatadorLayout() {
-  const loaderData = useLoaderData();
   const [colorScheme, setColorScheme] = useState<ColorScheme>("light");
   const toggleColorScheme = (value?: ColorScheme) =>
     setColorScheme(value || (colorScheme === "dark" ? "light" : "dark"));
@@ -58,7 +50,7 @@ export default function MatadorLayout() {
         <NavBar
           links={Navigations}
           srcLogo="/assets/matador.png"
-          footerText={`Matador ${loaderData}`}
+          footerText={`Matador`}
         >
           <Outlet />
         </NavBar>

--- a/remix.init/installer.sh
+++ b/remix.init/installer.sh
@@ -102,6 +102,23 @@ checkAppDir() {
   fi
 }
 
+checkEnvFile() {
+  local remixRootDir=$1
+
+  # if there is no .env file, create one and add env variables
+  if ! [[ -f "${remixRootDir}/.env" ]]; then 
+    echo -e "\x1b[1m[ ℹ️  ] Creating .env file with REDIS_URL variable\x1b[0m"
+    echo 'REDIS_URL=""' >> "${remixRootDir}/.env"
+    return
+  fi
+
+  # if there is a .env file, check if it has REDIS_URL env variables
+  if ! grep -q -E "REDIS_URL=*" "${remixRootDir}/.env"; then
+    echo -e "\x1b[1m[ ℹ️  ] Adding REDIS_URL variable to .env file\x1b[0m"
+    echo 'REDIS_URL=""' >> "${remixRootDir}/.env"
+  fi
+}
+
 main() {
   if [[ $# -gt 2 ]]; then 
     echo -e "\x1b[1m[ \x1b[31mError\x1b[39m ] invalid arguments, aborting\x1b[0m"
@@ -153,6 +170,8 @@ main() {
   rm "$tempDir/main.zip"
 
   rm -rf $tempDir
+
+  checkEnvFile $remixRootDir
 
   echo -e "\x1b[1m[ ✅ ] All done! Enjoy \x1b[36mMatador\x1b[39m!\x1b[0m"
 }


### PR DESCRIPTION
Close #42 

## Changelog

This PR refactors the installation script to insert the `REDIS_URL` env variables if it is missing in the `.env` file.

Does not check for a `.env.example` file.